### PR TITLE
Update the docs to use odoc

### DIFF
--- a/src/PPrint.ml
+++ b/src/PPrint.ml
@@ -10,8 +10,12 @@
 (*  License, with an exception, as described in the file LICENSE.         *)
 (**************************************************************************)
 
-(** A package of all of the above. *)
+(* A package of all of the above. *)
 
-include PPrintEngine
-include PPrintCombinators
+include PPrintEngine (** @inline *)
+
+include PPrintCombinators (** @inline *)
+
+(** {1 Printing OCaml values} *)
+
 module OCaml = PPrintOCaml

--- a/src/PPrint.ml
+++ b/src/PPrint.ml
@@ -14,6 +14,8 @@
 
 include PPrintEngine (** @inline *)
 
+(** {1:PPrintCombinators High level combinators} *)
+
 include PPrintCombinators (** @inline *)
 
 (** {1 Printing OCaml values} *)

--- a/src/PPrintCombinators.mli
+++ b/src/PPrintCombinators.mli
@@ -158,47 +158,52 @@ val url: string -> document
    box forms a hanging indent. *)
 val hang: int -> document -> document
 
-(** [prefix n b left right] has the following flat layout: {[
-left right
-]}
-and the following non-flat layout:
-{[
-left
-  right
-]}
-The parameter [n] controls the nesting of [right] (when not flat).
-The parameter [b] controls the number of spaces between [left] and [right]
-(when flat).
+(** [prefix n b left right] has the following flat layout:
+    {[
+      left right
+    ]}
+    and the following non-flat layout:
+    {[
+      left
+        right
+    ]}
+    The parameter [n] controls the nesting of [right] (when not flat).
+    The parameter [b] controls the number of spaces between [left] and [right]
+    (when flat).
  *)
 val prefix: int -> int -> document -> document -> document
 
 (** [jump n b right] is equivalent to [prefix n b empty right]. *)
 val jump: int -> int -> document -> document
 
-(** [infix n b middle left right] has the following flat layout: {[
-left middle right
-]}
-and the following non-flat layout: {[
-left middle
-  right
-]}
-The parameter [n] controls the nesting of [right] (when not flat).
-The parameter [b] controls the number of spaces between [left] and [middle]
-(always) and between [middle] and [right] (when flat).
+(** [infix n b middle left right] has the following flat layout:
+    {[
+      left middle right
+    ]}
+    and the following non-flat layout:
+    {[
+      left middle
+        right
+    ]}
+    The parameter [n] controls the nesting of [right] (when not flat).
+    The parameter [b] controls the number of spaces between [left] and [middle]
+    (always) and between [middle] and [right] (when flat).
 *)
 val infix: int -> int -> document -> document -> document -> document
 
-(** [surround n b opening contents closing] has the following flat layout: {[
-opening contents closing
-]}
-and the following non-flat layout: {[
-opening
-  contents
-closing
-]}
-The parameter [n] controls the nesting of [contents] (when not flat).
-The parameter [b] controls the number of spaces between [opening] and [contents]
-and between [contents] and [closing] (when flat).
+(** [surround n b opening contents closing] has the following flat layout:
+    {[
+      opening contents closing
+    ]}
+    and the following non-flat layout:
+    {[
+      opening
+        contents
+        closing
+    ]}
+    The parameter [n] controls the nesting of [contents] (when not flat).
+    The parameter [b] controls the number of spaces between [opening] and [contents]
+    and between [contents] and [closing] (when flat).
 *)
 val surround: int -> int -> document -> document -> document -> document
 

--- a/src/dune
+++ b/src/dune
@@ -4,3 +4,5 @@
   (modules :standard \ PPrintMini)
   (wrapped false)
 )
+
+(documentation)

--- a/src/index.mld
+++ b/src/index.mld
@@ -1,0 +1,125 @@
+{1 PPrint}
+
+{2:taste A taste of the layout language}
+ 
+At the heart of {!PPrint} is a little domain-specific language of
+documents. This language has a well-defined semantics, which the printing
+engine implements. This language rests upon a small number of fundamental
+concepts.
+
+There are combinators for creating atomic documents. For
+instance,
+
+{[
+string "hello"
+]}
+
+is a simple, unbreakable document.
+
+There is also a concatenation operator, which joins two documents.
+For instance,
+
+{[
+string "hello" ^^ string "world"
+]}
+
+is a composite document. It is in fact equivalent to [string "helloworld"].
+
+So far, nothing very exciting. The next two combinators are more original and
+interesting.
+
+The first of these combinators, [break 1], is a breakable space. If printed in
+flat mode, it produces an ordinary space character; if printed in normal mode,
+it produces a newline character.
+
+Yes, there are two printing modes, namely flat mode and normal mode. The
+printing engine goes back and forth between these two modes. Exactly where and
+how the engine switches from one mode to the other is controlled by the next
+combinator.
+
+The second of these combinators, [group], introduces a choice between flat
+mode and normal mode. It is a document transformer: if [d] is a document, then
+[group d] is a document. When the printing engine encounters [group d], two
+possibilities arise. The first possibility is to print all of [d] on a single
+line. This is known as flat mode. The engine tries this first (ignoring any
+[group] combinators inside [d]). If it succeeds, great. If it fails, by lack
+of space on the current line, then the engine backtracks and reverts to the
+second possibility, which is to simply ignore the [group] combinator, and just
+print [d]. This has subtle consequences: there might be further groups inside
+[d], and each of these groups will give rise to further choices.
+
+This gives rise to an interesting language, where [group] is used to indicate
+a choice point, and the appearance of [break] is dependent upon the choice
+point(s) that appear higher up in the hierarchical structure of the document.
+For instance, the document:
+
+{[
+group (string "This" ^^ break 1 ^^ string "is" ^^ break 1 ^^ string "pretty.")
+]}
+
+will be printed either on a single line, if it fits, or on three lines. It
+will not be printed on two lines: there is just one choice point, so either
+the two breakable spaces will be broken, or none of them will. By the way,
+this document can be abbreviated as follows:
+
+{[
+group (string "This" ^/^ string "is" ^/^ string "pretty.")
+]}
+
+On the other hand, the document:
+
+{[
+string "This" ^^
+group (break 1 ^^ string "is") ^^
+group (break 1 ^^ string "pretty.")
+]}
+
+could be printed on one, two, or three lines. There are two choice points,
+each of which influences one of the two breakable spaces. The two choices are
+independent of one another. Each of the words in the sentence `This is
+pretty.` will be printed on the current line if it fits, and on a new line
+otherwise. By the way, this document can be abbreviated as follows:
+
+{[
+flow (break 1) [
+  string "This" ;
+  string "is" ;
+  string "pretty."
+]
+]}
+
+There are more combinators, such as [nest], which controls indentation, and
+it is relatively easy to roll your own combinators on top of those that are
+provided.
+
+One limitation of the library is that the document must be entirely built in
+memory before it is printed. So far, we have used the library in small- to
+medium-scale applications, and this has not been a problem. In principle,
+one could work around this limitation by adding a new document constructor
+whose argument is a suspended document computation.
+
+{2 Acknowledgements}
+ 
+The document language and the printing engine are inspired by Daan Leijen's
+{{:http://www.cs.uu.nl/~daan/pprint.html}PPrint}
+library, which itself is based on the ideas developed by Philip
+Wadler in the paper
+{{:http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf}A Prettier Printer}.
+
+{i {b PPrint}} was written by François Pottier and Nicolas Pouillard, with
+contributions by Yann Régis-Gianas, Gabriel Scherer, and Jonathan
+Protzenko.
+
+
+{2 Installation}
+
+The library is available online
+({{:http://gallium.inria.fr/~fpottier/pprint/pprint.tar.gz}source code},
+{{:https://github.com/fpottier/pprint/}github},
+ {{:http://gallium.inria.fr/~fpottier/pprint/doc/}documentation}),
+and can also be installed via OPAM: just type [opam install pprint]
+if you already have a working OPAM installation.
+
+Have fun! Feel free to make comments, suggestions, and to let me know if
+and how you are using this library.
+

--- a/src/index.mld
+++ b/src/index.mld
@@ -1,5 +1,9 @@
 {1 PPrint}
 
+{i {b PPrint}} is an OCaml library for pretty-printing textual documents.
+
+{{!PPrint}{b The full API is browsable here}}.
+
 {2:taste A taste of the layout language}
  
 At the heart of {!PPrint} is a little domain-specific language of
@@ -106,7 +110,7 @@ library, which itself is based on the ideas developed by Philip
 Wadler in the paper
 {{:http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf}A Prettier Printer}.
 
-{i {b PPrint}} was written by François Pottier and Nicolas Pouillard, with
+{!section-pprint} was written by François Pottier and Nicolas Pouillard, with
 contributions by Yann Régis-Gianas, Gabriel Scherer, and Jonathan
 Protzenko.
 


### PR DESCRIPTION
This
- fixes some warnings emitted by odoc
- inlines some includes
- adds a custom landing page: currently the blog post where the syntax is switched from markdown to ocaml docs' syntax.

The result visible [here](http://parce-q.eu/~trefis/pprint-doc/pprint/index.html) (for reference, the ocamldoc version is [there](http://gallium.inria.fr/~fpottier/pprint/doc/).

N.B. the html output depends on https://github.com/ocaml/odoc/pull/413 (otherwise the ToC is not fully populated).