### PR TITLE
Don't leave unintentional trailing whitespaces

### DIFF
--- a/src/PPrintEngine.ml
+++ b/src/PPrintEngine.ml
@@ -81,29 +81,23 @@ let rec blanks output_fn n =
 (* ------------------------------------------------------------------------- *)
 
 class with_blank_buffering char substring = object(self)
-  val mutable blank_buffered = None 
+  val mutable blank_buffered = 0
 
   method private flush_blank =
-    match blank_buffered with
-    | None -> ()
-    | Some n -> 
-      blanks substring n;
-      blank_buffered <- None
+    blanks substring blank_buffered;
+    blank_buffered <- 0
 
   method char c : unit =
     begin match c with
-    | '\n' -> blank_buffered <- Some 0
+    | '\n' -> blank_buffered <- 0
     | _ -> self#flush_blank
     end;
     char c
 
   method substring s pos len =
-    if s == blank_buffer then (
-      blank_buffered <-
-        match blank_buffered with
-        | None -> Some len
-        | Some n -> Some (len + n)
-    ) else (
+    if s == blank_buffer then
+      blank_buffered <- blank_buffered + len
+    else (
       self#flush_blank;
       substring s pos len
     )

--- a/src/PPrintEngine.ml
+++ b/src/PPrintEngine.ml
@@ -80,6 +80,10 @@ let rec blanks output_fn n =
 
 (* ------------------------------------------------------------------------- *)
 
+(* A helper that will wrap other output classes so as to withhold blank
+   characters at the beginning of the line until it is known that the line is
+   nonempty. *)
+
 class with_blank_buffering char substring = object(self)
   val mutable blank_buffered = 0
 
@@ -95,6 +99,12 @@ class with_blank_buffering char substring = object(self)
     char c
 
   method substring s pos len =
+    (* We don't want to retain just any white character, if the user built his
+       document using [char ' '], then it would be incorrect not to print that
+       space.
+       We only buffer "internal" blanks, i.e. those resulting from indentation
+       or calls to [blank]. All those get printed from [blank_buffer], which is
+       not exported. *)
     if s == blank_buffer then
       blank_buffered <- blank_buffered + len
     else (


### PR DESCRIPTION
I'm proposing to buffer whitespaces coming from indentation or a use of `blank` (but only those) until something is printed after them on the line (and drop them otherwise).

The change is observable on the *single* test available in the repository.