### PR TITLE
Keep dune’s standard flags around

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
   (public_name pprint)
   (modules :standard \ PPrintMini)
   (wrapped false)
-  (flags "-w" "A-4")
+  (flags :standard -w +A-4)
 )
 
 (documentation)


### PR DESCRIPTION
Leaving the standard set around is probably a good idea (it contains e.g. -g)